### PR TITLE
Remove browser support warning message

### DIFF
--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -47,11 +47,7 @@
       <path fill="#FF005A" d="M113 0h2v2h-2z"/>
     </svg>
   </header>
-
-  <div class="message message--warning">
-    <p>CSS Grid Layout is currently supported by very few browsers and this page may not display as intended for you. Please <a href="http://caniuse.com/#feat=css-grid">check out current browser support</a> or <a href="https://www.google.com/chrome/browser/canary.html">download a supported browser</a>.</p>
-  </div>
-
+  
   <div class="subhead">container</div>
   
   {# container: display #}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/170145/36447090-9572b38e-1683-11e8-9e72-32da4782ab7c.png)

:)

another idea would be to make the warning box into an info box and link [rachelandrew/gridbugs](https://github.com/rachelandrew/gridbugs)